### PR TITLE
exclude logback.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,15 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/logback.xml</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.4</version>
                         <configuration>


### PR DESCRIPTION
prevents "Resource [logback.xml] occurs multiple times on the classpath."